### PR TITLE
Add AVD 6.1 support for metadata-based peer fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,144 +1,182 @@
-# ACT Topology Generation
+# ACT & ContainerLab Topology Generation
 
-This role generates ACT topology files based on AVD structured config files.
+This Ansible role generates topology files for both **Arista Cloud Test (ACT)** and **ContainerLab (clab)** from AVD structured config files.
 
-The default is to look for structured configs in ./intended/structured_configs/ and output the result to ./act/
+It reads the `ethernet_interfaces` from each device's structured config, extracts peer connection data, and builds the topology link definitions automatically. Supports both AVD 5.x (top-level peer fields) and AVD 6.x (`metadata` sub-key) structured config formats.
 
-You have to build an AVD project first and run the eos_designs role to build the structured configs before this role can be used.
+## Prerequisites
+
+You must run the AVD `eos_designs` role first to generate structured configs before this role can be used.
 
 ## Example Playbook
 
-Use the same top level group you have for your fabric for hosts, modify the input variables to the role to make the topology you want.
+Use the same top-level group you have for your fabric as `hosts`. Override role variables to customize the topology output.
 
 ```yaml
 ---
-- name: Build ACT Topology
-  hosts: ACT_FABRIC
+- name: Build ACT / ContainerLab Topology
+  hosts: FABRIC
   connection: local
   gather_facts: false
 
   tasks:
-    - name: Generate ACT Topology File
+    - name: Generate Topology Files
       import_role:
         name: act-topgen
 ```
 
-## Role Defaults
+## What Gets Generated
 
-```yaml
----
-# defaults file for act-topgen
+| Output | Location | Description |
+|--------|----------|-------------|
+| ACT topology | `act/topology.yml` | Nodes, links, and node_defaults for CE ACT |
+| ContainerLab topology | `clab/<name>.clab.yml` | Nodes, links, and kinds for containerlab |
+| Interface mapping | `clab/interface_mapping.json` | Maps cEOS `eth0` to `Management1` and all Ethernet interfaces used in the topology |
+| Base configs | `clab/configs/<hostname>.cfg` | Vanilla startup configs per device |
 
-# Input/Output directories and AVD structured config file format
-structured_folder: "intended/structured_configs/"
-avd_structured_config_file_format: yml
-output_folder: "act/"
-output_filename: "topology.yml"
+## Role Variables
 
-# Versions
-act_eos_version: "4.30.4M"
-act_generic_os_version: "Rocky-8.5"
-act_tools_os_version: "ubuntu-2204-lts"
-act_cvp_version: "2023.1.3"
+### Input / Output
 
-# Device (veos/generic) user/pass
-act_device_user: <some user>
-act_device_password: <some password>
-# List other ports that all EOS devices should have.
-# These cannot clash with ports already defined through the topology.
-act_default_ports: []
-# Adds device models from structured config metadata if present
-act_use_device_models: true
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `structured_folder` | `intended/structured_configs/` | Path to AVD structured config YAML files |
+| `avd_structured_config_file_format` | `yml` | File extension of structured configs |
+| `output_folder` | `act/` | ACT topology output directory |
+| `output_filename` | `topology.yml` | ACT topology output filename |
 
-# Extra node parameters
-act_cvp_user: <some user>
-act_cvp_password: <some password>
-act_cvp_instance_type: "singlenode"  # Currently the only supported type
-act_cvp_ip: "192.168.0.5"
-act_cvp_auto_configuration: true
-act_cvp_size: medium # supported values are medium, large, xlarge
-act_tools_server_ip: "192.168.0.6"
-act_tools_server_size: medium # supported values are medium, large, xlarge
-act_veos_size: medium # supported values are medium, large, xlarge
+### ACT Settings
 
-# Whether to add cvp and ansible node to topology
-act_add_cvp: true
-act_add_tools_server: true
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `act_eos_version` | `4.30.4M` | EOS version for ACT vEOS nodes |
+| `act_generic_os_version` | `Rocky-8.5` | OS version for ACT generic nodes |
+| `act_tools_os_version` | `ubuntu-2204-lts` | OS version for ACT tools-server |
+| `act_cvp_version` | `2023.1.3` | CVP version for ACT |
+| `act_device_user` | `cvpadmin` | Default username for EOS devices |
+| `act_device_password` | `""` | Default password for EOS devices |
+| `act_default_ports` | `[]` | Extra ports to add to all EOS nodes |
+| `act_use_device_models` | `true` | Include device models from structured config metadata |
+| `act_cvp_user` | `root` | CVP username |
+| `act_cvp_password` | `""` | CVP password |
+| `act_cvp_instance_type` | `singlenode` | CVP instance type |
+| `act_cvp_ip` | `192.168.0.5` | CVP management IP |
+| `act_cvp_auto_configuration` | `true` | Enable CVP auto-configuration |
+| `act_cvp_size` | `medium` | CVP instance size (`medium`, `large`, `xlarge`) |
+| `act_tools_server_ip` | `192.168.0.6` | Tools-server management IP |
+| `act_tools_server_size` | `medium` | Tools-server instance size |
+| `act_veos_size` | `medium` | Default vEOS instance size |
+| `act_add_cvp` | `true` | Add CVP node to ACT topology |
+| `act_add_tools_server` | `true` | Add tools-server node to ACT topology |
+| `act_add_connected_nodes` | `false` | Add non-fabric nodes (servers, endpoints) to topology |
+| `act_connected_nodes_map` | `{other: veos}` | Map AVD `peer_type` to ACT `node_type` |
+| `act_connected_nodes_range` | `192.168.0.128/25` | IP range for auto-assigned connected node IPs |
+| `act_use_old_connections` | `false` | Use legacy `nodes[].neighbors` format instead of `links[]` |
+| `act_veos_internet_access` | `false` | Enable internet access on vEOS devices |
 
-# Whether to add nodes that are not defined in the fabric
-# Example l3 peers, servers and other endpoints
-act_add_connected_nodes: false
-# For each peer_type that should be added,
-# the ACT node_type needs to be defined
-# Any peer_type that is not defined in this list
-# will not be added as a node in the topology
-act_connected_nodes_map:
-  other: 'veos'
-  # server: 'generic'
-  # network_port: 'generic'
-  # <peer_type in AVD>: <node_type in ACT>
+### ContainerLab Settings
 
-act_connected_nodes_range: 192.168.0.128/25
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `clab_name` | `demo` | ContainerLab topology name |
+| `clab_prefix` | `""` | ContainerLab name prefix (empty = use clab default) |
+| `clab_output_folder` | `{{ inventory_dir }}/clab/` | ContainerLab output directory |
+| `clab_output_filename` | `topology.clab.yml` | ContainerLab topology filename |
+| `clab_eos_version` | `arista/ceos:4.34.1F` | cEOS container image |
+| `clab_linux_image` | `ghcr.io/aristanetworks/aclabs/host-ubuntu:rev1.0` | Linux container image for servers |
+| `clab_add_tools_server` | `false` | Add a tools-server linux node |
+| `clab_tools_server_ip` | `null` | Tools-server management IP |
+| `clab_config_dir` | `configs` | Directory for startup config files |
+| `clab_config_default` | `default.cfg` | Default startup config filename |
+| `clab_avd_configs` | `{{ inventory_dir }}/intended/configs` | Path to AVD-generated EOS configs |
+| `clab_structured_folder` | `{{ inventory_dir }}/clab/intended/structured_configs` | Path to clab structured configs |
+| `clab_device_default` | `true` | Use vanilla configs (`true`) or AVD configs (`false`) as startup |
+| `clab_static_mgmt_ip` | `true` | Assign static management IPs from inventory |
+| `clab_interface_mapping_file` | `interface_mapping.json` | Interface mapping filename for cEOS |
+| `clab_mgmt_interface_name` | `Management1` | cEOS management interface name (AVD 6.x default) |
+| `clab_connected_nodes_map` | `{server: linux, workstation: linux}` | Map AVD `peer_type` to containerlab node `kind` |
 
-# # Extra nodes to add
-# act_additional_nodes: []
+### Interface Mapping (AVD 6.x)
 
-# Use older style ACT topology connections (nodes[].neighbors)
-act_use_old_connections: false
+AVD 6.x in digital twin mode defaults the management interface to `Management1` instead of `Management0`. The role automatically:
 
-# internet for veos devices
-act_veos_internet_access: false
+1. Generates an `interface_mapping.json` that maps `eth0` to `Management1` plus all Ethernet interfaces used in the topology
+2. Binds the mapping file into each cEOS container at `/mnt/flash/EosIntfMapping.json`
+3. Sets `enforce-startup-config: true` on the `arista_ceos` kind
 
+To change the management interface name, override `clab_mgmt_interface_name`.
 
-## ContainerLAB
+## AVD Compatibility
 
-# Name of Containerlab
-clab_name: "demo"
+The role supports both AVD 5.x and 6.x structured config formats:
 
-# Prefix for the lab
-clab_prefix: ""
+- **AVD 5.x**: `peer`, `peer_interface`, `peer_type` are top-level keys on each `ethernet_interfaces` entry
+- **AVD 6.x**: These fields moved under a `metadata` sub-key
 
-# Folder to create to store the Containerlab config and data files
-clab_output_folder: "{{ inventory_dir }}/clab/"
-
-# Default output name of the Containerlab config file.
-clab_output_filename: "topology.clab.yml"
-
-# cEOS version to use
-clab_eos_version: "arista/ceos:4.34.1F"
-
-# Linux container image to use.
-clab_linux_image: "ghcr.io/aristanetworks/aclabs/host-ubuntu:rev1.0"
-
-# Create linux tools device
-clab_add_tools_server: false
-
-# Tool Server IP
-clab_tools_server_ip: null
-
-# Vanilla config location (gets auto created)
-clab_config_dir: "configs"
-
-# Default config file to use
-clab_config_default: "default.cfg"
-
-# AVD configs folder location
-clab_avd_configs: "{{ inventory_dir }}/intended/configs"
-
-# AVD clab Structured Folder
-clab_structured_folder: "{{ inventory_dir }}/clab/intended/structured_configs"
-
-# Use the default vanilla config or AVD
-clab_device_default: true
-
-# Use the default vanilla config or AVD
-clab_static_mgmt_ip: false
-```
+The templates automatically check `metadata` first and fall back to top-level keys.
 
 ## Inventory Update Script
 
-Attached in this repo is also a script 'update-inv.py' that updates an ansible inventory based on the information in a downloaded ACT inventory file. This is useful as ACT generates randomized IP addresses for all nodes, and manually updating your ansible inventory after the lab is deployed is a total pain in the behind.
+The `update_clab_act_inventory` script (located at `common/scripts/update_clab_act_inventory` in [ceos-act-projects](https://github.com/wdion-arista/ceos-act-projects)) generates environment-specific inventory files from your production `inventory.yml`. It reads IP addresses from either a ContainerLab or ACT deployment and produces a new inventory with updated `ansible_host` values and the appropriate environment group name.
 
-Usage:
+### ContainerLab Inventory
 
-python update-inv.py -i < path/to/ansible-inventory-to-update > -a < path/to/downloaded/act-inventory-file >
+After deploying a containerlab topology, generate `inventory-containerlab.yml` from the clab-generated ansible inventory:
+
+```bash
+python common/scripts/update_clab_act_inventory \
+  --inv_file sites/eastcoast/inventory.yml \
+  --fabric_name EASTCOAST_FABRIC \
+  --env_name PROD \
+  --clab sites/eastcoast/clab/clab-MandE-eastcoast/ansible-inventory.yml \
+  --site eastcoast
+```
+
+This:
+- Copies the source inventory
+- Replaces `ansible_host` IPs with the containerlab management IPs
+- Renames the `PROD` group to `CLAB`
+- Removes `clab_mgmt_ip` and `act_mgmt_ip` host vars
+- Saves to `inventory-containerlab.yml`
+
+### ACT Inventory
+
+After deploying an ACT lab, generate `inventory-act.yml` from the ACT lab resource file:
+
+```bash
+python common/scripts/update_clab_act_inventory \
+  --inv_file sites/eastcoast/inventory.yml \
+  --fabric_name EASTCOAST_FABRIC \
+  --env_name PROD \
+  --act sites/eastcoast/act/lab-resource.yml
+```
+
+This:
+- Copies the source inventory
+- Replaces `ansible_host` IPs with ACT `internal_ip` values
+- Adds `cloud_ip` for each device
+- Renames the `PROD` group to `ACT`
+- Updates tools-server and server IPs if present
+- Saves to `inventory-act.yml`
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--inv_file` | Yes | Path to the source `inventory.yml` |
+| `--fabric_name` | Yes | Top-level fabric group name (e.g., `EASTCOAST_FABRIC`) |
+| `--env_name` | No | Parent environment group to rename (e.g., `PROD`) |
+| `--clab` | No* | Path to containerlab's `ansible-inventory.yml` |
+| `--act` | No* | Path to ACT lab resource YAML |
+| `--site` | No | Site name, appended to `PROJECT_NAME` for clab hostname stripping |
+| `--inventory-type` | No | Inventory structure: `default` (group -> hosts) or `sub_groups` (group -> children -> sub_group -> hosts). Defaults to `default` or `INVENTORY_TYPE` env var |
+| `--verbose` | No | Enable verbose output |
+
+\* One of `--clab` or `--act` is required.
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `PROJECT_NAME` | Project name used in containerlab hostnames (set in `.env`, default: `test`) |
+| `INVENTORY_TYPE` | Default inventory structure type (set in `.env`, default: `default`) |

--- a/act-topgen/README.md
+++ b/act-topgen/README.md
@@ -1,135 +1,22 @@
-# ACT Topology Generation
+# act-topgen
 
-This role generates ACT topology files based on AVD structured config files.
+Ansible role that generates topology files for **Arista Cloud Test (ACT)** and **ContainerLab** from AVD structured configurations.
 
-The default is to look for structured configs in ./intended/structured_configs/ and output the result to ./act/
+Supports AVD 5.x and 6.x structured config formats (peer fields at top-level or under `metadata`).
 
-You have to build an AVD project first and run the eos_designs role to build the structured configs before this role can be used.
+## Requirements
 
-## Example Playbook
+- AVD `eos_designs` role must be run first to generate structured configs
+- `arista.avd` Ansible collection installed
 
-Use the same top level group you have for your fabric for hosts, modify the input variables to the role to make the topology you want.
+## Role Variables
 
-```yaml
----
-- name: Build ACT Topology
-  hosts: ACT_FABRIC
-  connection: local
-  gather_facts: false
+See the top-level [README.md](../README.md) for the full variable reference.
 
-  tasks:
-    - name: Generate ACT Topology File
-      import_role:
-        name: act-topgen
-```
+## Dependencies
 
-## Role Defaults
+None.
 
-```yaml
----
-# defaults file for act-topgen
+## License
 
-# Input/Output directories and AVD structured config file format
-structured_folder: "intended/structured_configs/"
-avd_structured_config_file_format: yml
-output_folder: "act/"
-output_filename: "topology.yml"
-
-# Versions
-act_eos_version: "4.30.4M"
-act_generic_os_version: "Rocky-8.5"
-act_tools_os_version: "ubuntu-2204-lts"
-act_cvp_version: "2023.1.3"
-
-# Device (veos/generic) user/pass
-act_device_user: <some user>
-act_device_password: <some password>
-# List other ports that all EOS devices should have.
-# These cannot clash with ports already defined through the topology.
-act_default_ports: []
-# Adds device models from structured config metadata if present
-act_use_device_models: true
-
-# Extra node parameters
-act_cvp_user: <some user>
-act_cvp_password: <some password>
-act_cvp_instance_type: "singlenode"  # Currently the only supported type
-act_cvp_ip: "192.168.0.5"
-act_cvp_auto_configuration: true
-act_cvp_size: medium # supported values are medium, large, xlarge
-act_tools_server_ip: "192.168.0.6"
-act_tools_server_size: medium # supported values are medium, large, xlarge
-act_veos_size: medium # supported values are medium, large, xlarge
-
-# Whether to add cvp and ansible node to topology
-act_add_cvp: true
-act_add_tools_server: true
-
-# Whether to add nodes that are not defined in the fabric
-# Example l3 peers, servers and other endpoints
-act_add_connected_nodes: false
-# For each peer_type that should be added,
-# the ACT node_type needs to be defined
-# Any peer_type that is not defined in this list
-# will not be added as a node in the topology
-act_connected_nodes_map:
-  other: 'veos'
-  # server: 'generic'
-  # network_port: 'generic'
-  # <peer_type in AVD>: <node_type in ACT>
-
-act_connected_nodes_range: 192.168.0.128/25
-
-# # Extra nodes to add
-# act_additional_nodes: []
-
-# Use older style ACT topology connections (nodes[].neighbors)
-act_use_old_connections: false
-```
-
-## ContainerLab addon
-
-```yaml
----
-# defaults file for act-topgen - containerlab
-
-# Name of Containerlab
-clab_name: "demo"
-
-# Prefix for the lab
-clab_prefix: ""
-
-# Folder to create to store the Containerlab config and data files
-clab_output_folder: "clab"
-
-# Default output name of the Containerlab config file.
-clab_output_filename: "topology.clab.yml"
-
-# cEOS version to use
-clab_eos_version: "arista/ceos:4.34.1F"
-
-# Create linux tools device
-clab_add_tools_server: true
-
-# Linux container image to use.
-clab_linux_image: "ghcr.io/aristanetworks/aclabs/host-ubuntu:rev1.0"
-
-# Vanilla config location (gets auto created)
-clab_config_dir: "configs"
-
-# Default config file to use
-clab_config_default: "default.cfg"
-
-# AVD configs folder location
-clab_avd_configs: "../intended/configs"
-
-# AVD clab Structured Folder
-clab_structured_folder: "{{ inventory_dir }}/clab/intended/structured_configs"
-
-# Use the default vanilla config or AVD
-clab_device_default: true
-
-# Use the default vanilla config or AVD
-clab_static_mgmt_ip: false
-
-```
+Apache-2.0

--- a/act-topgen/defaults/main.yml
+++ b/act-topgen/defaults/main.yml
@@ -21,6 +21,17 @@ act_device_password: ""
 act_default_ports: []
 # Adds device models from structured config metadata if present
 act_use_device_models: true
+# Map AVD platform family names to ACT-supported device models
+# AVD 6.x uses short platform names (e.g., 7280SR3) that may not match
+# the full model numbers ACT requires (e.g., 7280SR3-48YC8)
+act_device_model_map:
+  "7280SR3": "7280SR3-48YC8"
+  "7280R3": "7280SR3-48YC8"
+  "7280R": "7280SR-48C6"
+  "7280R2": "7280SR2-48YC6"
+  "7020R": "7020SR-24C2"
+  "7020TD": "7020TR-48"
+  "720XP": "720XP-48ZC2"
 
 # Extra node parameters
 act_cvp_user: "root"
@@ -104,7 +115,11 @@ clab_structured_folder: "{{ inventory_dir }}/clab/intended/structured_configs"
 clab_device_default: true
 
 # Use the default vanilla config or AVD
-clab_static_mgmt_ip: false
+clab_static_mgmt_ip: true
+
+# Interface mapping file for cEOS Management1 (AVD 6.x digital twin default)
+clab_interface_mapping_file: "interface_mapping.json"
+clab_mgmt_interface_name: "Management1"
 
 # Server mapping to just for containerlab vms
 clab_connected_nodes_map:

--- a/act-topgen/tasks/main.yml
+++ b/act-topgen/tasks/main.yml
@@ -74,6 +74,14 @@
     dest: "{{ clab_output_folder }}/{{ clab_output_filename }}"
     mode: "0664"
 
+- name: Generate cEOS interface mapping file
+  delegate_to: localhost
+  run_once: true
+  ansible.builtin.template:
+    src: clab-interface-mapping.j2
+    dest: "{{ clab_output_folder }}/{{ clab_interface_mapping_file }}"
+    mode: "0664"
+
 - name: Build basefile clab
   delegate_to: localhost
   ansible.builtin.template:

--- a/act-topgen/templates/act-logic.j2
+++ b/act-topgen/templates/act-logic.j2
@@ -56,8 +56,10 @@
 {%         if act_use_device_models is true %}
 {%             if hostvars[node].metadata is defined %}
 {%                 if hostvars[node].metadata.platform is defined and hostvars[node].metadata.platform is not none %}
-{%                     if hostvars[node].metadata.platform | lower is not in ["veos-lab", "veos_lab", "veos", "ceos-lab", "ceos_lab", "ceos"] %}
-{%                         do node_dict[nodename].update({"device_model": hostvars[node].metadata.platform }) %}
+{%                     set _platform = hostvars[node].metadata.platform %}
+{%                     if _platform | lower is not in ["veos-lab", "veos_lab", "veos", "ceos-lab", "ceos_lab", "ceos", "ceoslab"] %}
+{%                         set _device_model = act_device_model_map[_platform] | default(_platform) %}
+{%                         do node_dict[nodename].update({"device_model": _device_model}) %}
 {%                     endif %}
 {%                 endif %}
 {%             endif %}
@@ -65,34 +67,39 @@
 {#         building links definition as per new ACT standard #}
 {%         if not act_use_old_connections %}
 {%             for ifdata in node_ethernet_interfaces %}
-{%                 if "peer" in ifdata and "peer_interface" in ifdata and "." not in ifdata.name %}
+{#                 AVD 6.x moved peer fields under metadata; fall back to top-level for AVD 5.x #}
+{%                 set _peer = ifdata.get("metadata", {}).get("peer", ifdata.get("peer")) %}
+{%                 set _peer_interface = ifdata.get("metadata", {}).get("peer_interface", ifdata.get("peer_interface")) %}
+{%                 set _peer_type = ifdata.get("metadata", {}).get("peer_type", ifdata.get("peer_type", "")) %}
+{%                 if _peer is not none and _peer_interface is not none and "." not in ifdata.name %}
 {#                     add fabric nodes #}
-{%                     if ifdata.peer in ansible_play_hosts_all or (act_add_connected_nodes == true and ifdata["peer_type"] in act_connected_nodes_map) %}
-{%                         set link_nodes = [node | replace("_", "-"), ifdata.peer | replace("_", "-")] | join("_") %}
-{%                         set link_ifs = [ifdata.name, ifdata.peer_interface] | join("_") %}
+{%                     if _peer in ansible_play_hosts_all or (act_add_connected_nodes == true and _peer_type in act_connected_nodes_map) %}
+{%                         set link_nodes = [node | replace("_", "-"), _peer | replace("_", "-")] | join("_") %}
+{%                         set link_ifs = [ifdata.name, _peer_interface] | join("_") %}
 {%                         if link_nodes not in unique_links %}
 {%                             do unique_links.update({link_nodes: [link_ifs]}) %}
 {%                         elif link_ifs not in unique_links[link_nodes] %}
 {%                             do unique_links[link_nodes].append(link_ifs) %}
 {%                         endif %}
 {#                         add external nodes to topology while we're looking at peers #}
-{%                         if act_add_connected_nodes == true and ifdata["peer_type"] in act_connected_nodes_map %}
-{%                             set peer_node = ifdata["peer"] | replace("_", "-") %}
+{%                         if act_add_connected_nodes == true and _peer_type in act_connected_nodes_map %}
+{%                             set peer_node = _peer | replace("_", "-") %}
 {%                             set avd_ext_node_neighbordict = dict() %}
 {%                             if peer_node not in avd_ext_nodes and peer_node not in ansible_play_hosts_all %}
 {%                                 do avd_ext_nodes.update({peer_node: dict()}) %}
 {%                                 set mgmt_ip = act_connected_nodes_range | ansible.utils.ipaddr('network') | ansible.utils.ipmath(ns.avd_ext_nodes_count)  %}
 {%                                 set ns.avd_ext_nodes_count = ns.avd_ext_nodes_count + 1 %}
 {%                                 do avd_ext_nodes[peer_node].update({"ip_addr": hostvars[peer_node].act_mgmt_ip | default(mgmt_ip)}) %}
-{%                                 do avd_ext_nodes[peer_node].update({"node_type": act_connected_nodes_map[ifdata["peer_type"]]}) %}
-{%                                 do avd_ext_nodes[peer_node].update({"ports": []}) %}
-{# {%                                 do avd_ext_nodes[peer_node].update({"ports2": hostvars[peer_node].act_mgmt_ip}) %} #}
+{%                                 do avd_ext_nodes[peer_node].update({"node_type": act_connected_nodes_map[_peer_type]}) %}
+{%                                 if act_connected_nodes_map[_peer_type] == "veos" %}
+{%                                     do avd_ext_nodes[peer_node].update({"ports": []}) %}
+{%                                 endif %}
 {%                                 if hostvars[peer_node].act_veos_internet_access | default(false) and avd_ext_nodes[peer_node]["node_type"] == "generic" %}
 {%                                   do avd_ext_nodes[peer_node].update({"internet_access": true}) %}
 {%                                 endif %}
 {%                             endif %}
 {%                         endif %}
-{%                     elif ifdata.peer not in ansible_play_hosts_all %}
+{%                     elif _peer not in ansible_play_hosts_all %}
 {%                         do node_dict[nodename].ports.append(ifdata.name) %}
 {%                     endif %}
 {%                 endif %}
@@ -110,27 +117,31 @@
 {%         endif %}
 {#         old ACT standard way to build node connections #}
 {%         for ifdata in node_ethernet_interfaces %}
-{%             if "peer" in ifdata and "peer_interface" in ifdata and "." not in ifdata.name %}
+{#             AVD 6.x moved peer fields under metadata; fall back to top-level for AVD 5.x #}
+{%             set _peer = ifdata.get("metadata", {}).get("peer", ifdata.get("peer")) %}
+{%             set _peer_interface = ifdata.get("metadata", {}).get("peer_interface", ifdata.get("peer_interface")) %}
+{%             set _peer_type = ifdata.get("metadata", {}).get("peer_type", ifdata.get("peer_type", "")) %}
+{%             if _peer is not none and _peer_interface is not none and "." not in ifdata.name %}
 {#                 add fabric connected nodes #}
-{%                 if ifdata["peer"] in ansible_play_hosts_all and act_use_old_connections %}
+{%                 if _peer in ansible_play_hosts_all and act_use_old_connections %}
 {%                     set neighbordict = dict() %}
-{%                     do neighbordict.update({"neighborDevice": ifdata["peer"] | replace("_", "-")}) %}
-{%                     do neighbordict.update({"neighborPort": ifdata["peer_interface"]}) %}
+{%                     do neighbordict.update({"neighborDevice": _peer | replace("_", "-")}) %}
+{%                     do neighbordict.update({"neighborPort": _peer_interface}) %}
 {%                     do neighbordict.update({"port": ifdata.name}) %}
 {%                     do node_dict[nodename]["neighbors"].append(neighbordict) %}
 {#                 add non-fabric connected nodes if toggle is set and peer_type is within given map #}
-{%                 elif act_add_connected_nodes == true and ifdata["peer_type"] in act_connected_nodes_map and act_use_old_connections %}
-{%                     set peer_node = ifdata["peer"] | replace("_", "-") %}
+{%                 elif act_add_connected_nodes == true and _peer_type in act_connected_nodes_map and act_use_old_connections %}
+{%                     set peer_node = _peer | replace("_", "-") %}
 {%                     set avd_ext_node_neighbordict = dict() %}
 {%                     do avd_ext_node_neighbordict.update({"neighborDevice": nodename}) %}
 {%                     do avd_ext_node_neighbordict.update({"neighborPort": ifdata.name}) %}
-{%                     do avd_ext_node_neighbordict.update({"port": ifdata["peer_interface"]}) %}
+{%                     do avd_ext_node_neighbordict.update({"port": _peer_interface}) %}
 {%                     if peer_node not in avd_ext_nodes and peer_node not in ansible_play_hosts_all %}
 {%                         do avd_ext_nodes.update({peer_node: dict()}) %}
 {%                         set mgmt_ip = act_connected_nodes_range | ansible.utils.ipaddr('network') | ansible.utils.ipmath(ns.avd_ext_nodes_count)  %}
 {%                         set ns.avd_ext_nodes_count = ns.avd_ext_nodes_count + 1 %}
 {%                         do avd_ext_nodes[peer_node].update({"ip_addr": mgmt_ip}) %}
-{%                         do avd_ext_nodes[peer_node].update({"node_type": act_connected_nodes_map[ifdata["peer_type"]]}) %}
+{%                         do avd_ext_nodes[peer_node].update({"node_type": act_connected_nodes_map[_peer_type]}) %}
 {%                         do avd_ext_nodes[peer_node].update({"neighbors": []}) %}
 {%                         do avd_ext_nodes[peer_node].update({"ports": []}) %}
 {%                         do avd_ext_nodes[peer_node]["neighbors"].append(avd_ext_node_neighbordict) %}
@@ -138,8 +149,8 @@
 {%                         do avd_ext_nodes[peer_node]["neighbors"].append(avd_ext_node_neighbordict) %}
 {%                     endif %}
 {%                     set neighbordict = dict() %}
-{%                     do neighbordict.update({"neighborDevice": ifdata["peer"] | replace("_", "-")}) %}
-{%                     do neighbordict.update({"neighborPort": ifdata["peer_interface"]}) %}
+{%                     do neighbordict.update({"neighborDevice": _peer | replace("_", "-")}) %}
+{%                     do neighbordict.update({"neighborPort": _peer_interface}) %}
 {%                     do neighbordict.update({"port": ifdata.name}) %}
 {%                     do node_dict[nodename]["neighbors"].append(neighbordict) %}
 {%                 elif act_use_old_connections %}

--- a/act-topgen/templates/clab-interface-mapping.j2
+++ b/act-topgen/templates/clab-interface-mapping.j2
@@ -1,0 +1,21 @@
+{% set all_eth = {} -%}
+{% for node in ansible_play_hosts_all -%}
+{%   if hostvars[node].ethernet_interfaces is defined -%}
+{%     for ifdata in hostvars[node].ethernet_interfaces -%}
+{%       if ifdata.name is defined and "." not in ifdata.name -%}
+{%         set eth_name = ifdata.name | replace("/", "_") | replace("Ethernet", "eth") -%}
+{%         do all_eth.update({eth_name: ifdata.name}) -%}
+{%       endif -%}
+{%     endfor -%}
+{%   endif -%}
+{% endfor -%}
+{
+    "ManagementIntf": {
+        "eth0": "{{ clab_mgmt_interface_name }}"
+    },
+    "EthernetIntf": {
+{% for eth_name, eos_name in all_eth | dictsort %}
+        "{{ eth_name }}": "{{ eos_name }}"{{ "," if not loop.last else "" }}
+{% endfor %}
+    }
+}

--- a/act-topgen/templates/clab-logic.j2
+++ b/act-topgen/templates/clab-logic.j2
@@ -3,6 +3,7 @@
 {% set avd_ext_nodes = {} %}
 {% set unique_links = {} %}
 {% set act_links = [] %}
+{% set all_eth_interfaces = {} %}
 {% set ns = namespace(avd_ext_nodes_count = 0) %}
 {% for node in ansible_play_hosts_all | arista.avd.natural_sort %}
 {%     if hostvars[node].ethernet_interfaces is defined %}
@@ -53,25 +54,33 @@
 {#         building links definition as per new ACT standard #}
 {%         if not act_use_old_connections %}
 {%             for ifdata in node_ethernet_interfaces %}
-{%                 if "peer" in ifdata and "peer_interface" in ifdata and "." not in ifdata.name %}
+{#                 AVD 6.x moved peer fields under metadata; fall back to top-level for AVD 5.x #}
+{%                 set _peer = ifdata.get("metadata", {}).get("peer", ifdata.get("peer")) %}
+{%                 set _peer_interface = ifdata.get("metadata", {}).get("peer_interface", ifdata.get("peer_interface")) %}
+{%                 set _peer_type = ifdata.get("metadata", {}).get("peer_type", ifdata.get("peer_type", "")) %}
+{%                 if _peer is not none and _peer_interface is not none and "." not in ifdata.name %}
 {#                     add fabric nodes #}
-{%                     if ifdata.peer in ansible_play_hosts_all or (act_add_connected_nodes == true and ifdata["peer_type"] in clab_connected_nodes_map) %}
-{%                         set link_nodes = [node | replace("_", "-"), ifdata.peer | replace("_", "-")] | join("_") %}
-{%                         set link_ifs = [ifdata.name, ifdata.peer_interface] | join("_") %}
+{%                     if _peer in ansible_play_hosts_all or (act_add_connected_nodes == true and _peer_type in clab_connected_nodes_map) %}
+{%                         set link_nodes = [node | replace("_", "-"), _peer | replace("_", "-")] | join("_") %}
+{%                         set link_ifs = [ifdata.name, _peer_interface] | join("_") %}
+{#                         collect interfaces for interface mapping #}
+{%                         set _eth_local = ifdata.name | replace("/", "_") | replace("Ethernet", "eth") %}
+{%                         set _eth_peer = _peer_interface | replace("/", "_") | replace("Ethernet", "eth") %}
+{%                         do all_eth_interfaces.update({_eth_local: ifdata.name, _eth_peer: _peer_interface}) %}
 {%                         if link_nodes not in unique_links %}
 {%                             do unique_links.update({link_nodes: [link_ifs]}) %}
 {%                         elif link_ifs not in unique_links[link_nodes] %}
 {%                             do unique_links[link_nodes].append(link_ifs) %}
 {%                         endif %}
 {#                         add external nodes to topology while we're looking at peers #}
-{%                         if act_add_connected_nodes == true and ifdata["peer_type"] in clab_connected_nodes_map %}
-{%                             set peer_node = ifdata["peer"] | replace("_", "-") %}
+{%                         if act_add_connected_nodes == true and _peer_type in clab_connected_nodes_map %}
+{%                             set peer_node = _peer | replace("_", "-") %}
 {%                             set avd_ext_node_neighbordict = dict() %}
 {%                             if peer_node not in avd_ext_nodes and peer_node not in ansible_play_hosts_all %}
 {%                                 do avd_ext_nodes.update({peer_node: dict()}) %}
 {%                                 set mgmt_ip = act_connected_nodes_range | ansible.utils.ipaddr('network') | ansible.utils.ipmath(ns.avd_ext_nodes_count)  %}
 {%                                 set ns.avd_ext_nodes_count = ns.avd_ext_nodes_count + 1 %}
-{%                                 do avd_ext_nodes[peer_node].update({"kind": clab_connected_nodes_map[ifdata["peer_type"]]}) %}
+{%                                 do avd_ext_nodes[peer_node].update({"kind": clab_connected_nodes_map[_peer_type]}) %}
 {%                                 if hostvars[peer_node].clab_mgmt_ip is defined and hostvars[peer_node].clab_mgmt_ip | length > 0 %}
 {%                                     do avd_ext_nodes[peer_node].update({"mgmt-ipv4": hostvars[peer_node].clab_mgmt_ip}) %}
 {%                                 else %}
@@ -99,34 +108,38 @@
 {%         endif %}
 {#         old ACT standard way to build node connections #}
 {%         for ifdata in node_ethernet_interfaces %}
-{%             if "peer" in ifdata and "peer_interface" in ifdata and "." not in ifdata.name %}
+{#             AVD 6.x moved peer fields under metadata; fall back to top-level for AVD 5.x #}
+{%             set _peer = ifdata.get("metadata", {}).get("peer", ifdata.get("peer")) %}
+{%             set _peer_interface = ifdata.get("metadata", {}).get("peer_interface", ifdata.get("peer_interface")) %}
+{%             set _peer_type = ifdata.get("metadata", {}).get("peer_type", ifdata.get("peer_type", "")) %}
+{%             if _peer is not none and _peer_interface is not none and "." not in ifdata.name %}
 {#                 add fabric connected nodes #}
-{%                 if ifdata["peer"] in ansible_play_hosts_all and act_use_old_connections %}
+{%                 if _peer in ansible_play_hosts_all and act_use_old_connections %}
 {%                     set neighbordict = dict() %}
-{%                     do neighbordict.update({"neighborDevice": ifdata["peer"] | replace("_", "-")}) %}
-{%                     do neighbordict.update({"neighborPort": ifdata["peer_interface"]}) %}
+{%                     do neighbordict.update({"neighborDevice": _peer | replace("_", "-")}) %}
+{%                     do neighbordict.update({"neighborPort": _peer_interface}) %}
 {%                     do neighbordict.update({"port": ifdata.name}) %}
 {%                     do node_dict[nodename]["neighbors"].append(neighbordict) %}
 {#                 add non-fabric connected nodes if toggle is set and peer_type is within given map #}
-{%                 elif act_add_connected_nodes == true and ifdata["peer_type"] in clab_connected_nodes_map and act_use_old_connections %}
-{%                     set peer_node = ifdata["peer"] | replace("_", "-") %}
+{%                 elif act_add_connected_nodes == true and _peer_type in clab_connected_nodes_map and act_use_old_connections %}
+{%                     set peer_node = _peer | replace("_", "-") %}
 {%                     set avd_ext_node_neighbordict = dict() %}
 {%                     do avd_ext_node_neighbordict.update({"neighborDevice": nodename}) %}
 {%                     do avd_ext_node_neighbordict.update({"neighborPort": ifdata.name}) %}
-{%                     do avd_ext_node_neighbordict.update({"port": ifdata["peer_interface"]}) %}
+{%                     do avd_ext_node_neighbordict.update({"port": _peer_interface}) %}
 {%                     if peer_node not in avd_ext_nodes and peer_node not in ansible_play_hosts_all %}
 {%                         do avd_ext_nodes.update({peer_node: dict()}) %}
 {%                         set mgmt_ip = act_connected_nodes_range | ansible.utils.ipaddr('network') | ansible.utils.ipmath(ns.avd_ext_nodes_count)  %}
 {%                         set ns.avd_ext_nodes_count = ns.avd_ext_nodes_count + 1 %}
-{%                         do avd_ext_nodes[peer_node].update({"kind2": clab_connected_nodes_map[ifdata["peer_type"]]}) %}
+{%                         do avd_ext_nodes[peer_node].update({"kind2": clab_connected_nodes_map[_peer_type]}) %}
 {%                         do avd_ext_nodes[peer_node].update({"neighbors": []}) %}
 {%                         do avd_ext_nodes[peer_node]["neighbors"].append(avd_ext_node_neighbordict) %}
 {%                     else %}
 {%                         do avd_ext_nodes[peer_node]["neighbors"].append(avd_ext_node_neighbordict) %}
 {%                     endif %}
 {%                     set neighbordict = dict() %}
-{%                     do neighbordict.update({"neighborDevice": ifdata["peer"] | replace("_", "-")}) %}
-{%                     do neighbordict.update({"neighborPort": ifdata["peer_interface"]}) %}
+{%                     do neighbordict.update({"neighborDevice": _peer | replace("_", "-")}) %}
+{%                     do neighbordict.update({"neighborPort": _peer_interface}) %}
 {%                     do neighbordict.update({"port": ifdata.name}) %}
 {%                     do node_dict[nodename]["neighbors"].append(neighbordict) %}
 {%                 endif %}
@@ -152,7 +165,7 @@
 {% set nodes_data.nodes = {"nodes": nodes_list} %}
 {# Build Topology #}
 {% set kinds = dict() %}
-{% do kinds.update({"arista_ceos": {"image": clab_eos_version ,"startup-config": clab_config_dir ~ "/" ~ clab_config_default  , "env": {"USERNAME": act_device_user, "PASSWORD": act_device_password, "CLAB_MGMT_VRF": "MGMT"}}}) %}
+{% do kinds.update({"arista_ceos": {"enforce-startup-config": true, "image": clab_eos_version, "startup-config": clab_config_dir ~ "/" ~ clab_config_default, "env": {"USERNAME": act_device_user, "PASSWORD": act_device_password, "CLAB_MGMT_VRF": "MGMT"}, "binds": [clab_interface_mapping_file ~ ":/mnt/flash/EosIntfMapping.json:ro"]}}) %}
 {# {% do kind.update({"generic": {"username": act_device_user, "password": act_device_password, "version": act_generic_os_version}}) %} #}
 {% do kinds.update({"linux": {"image": clab_linux_image, "env" : {"USERNAME": "admin", "PASSWORD": "admin" }}}) %}
 {# {% do kinds.update({"generic": {"image": clab_linux_image, "env" : {"USERNAME": "admin", "PASSWORD": "admin" }}}) %} #}
@@ -160,4 +173,5 @@
 {% set topology.kinds = dict({"kinds": kinds})  %}
 {% set topology.nodes = dict({"nodes": nodes_list})  %}
 {% set topology.act_links = {"links": act_links} %}
+{% set topology.all_eth_interfaces = all_eth_interfaces %}
 

--- a/example/requirements.yml
+++ b/example/requirements.yml
@@ -3,12 +3,9 @@ roles:
   - name: act-topgen
     src: https://github.com/wdion-arista/act_topgen.git
     scm: git
-    # version: v1.0.2
+    # version: v1.0.8
     version: main
-  # - name: arista.avd.eos_designs_to_containerlab
-  #   src: https://github.com/wdion-arista/eos_designs_to_containerlab.git
-  #   scm: git
-  #   version: main
+
 collections:
   - name: community.general
   - name: community.docker

--- a/example/requirements.yml
+++ b/example/requirements.yml
@@ -3,7 +3,7 @@ roles:
   - name: act-topgen
     src: https://github.com/wdion-arista/act_topgen.git
     scm: git
-    # version: v1.0.8
+    # version: v1.1.1
     version: main
 
 collections:


### PR DESCRIPTION
## Summary

This PR adds support for AVD 6.1 structured config format where `peer`, `peer_interface`, and `peer_type` fields moved under a `metadata` sub-key on each `ethernet_interfaces` entry. All templates remain backward-compatible with AVD 5.x.

## Detailed Changes

### AVD 6.x Metadata Support (templates)
- **`act-topgen/templates/act-logic.j2`** — Updated both new-style (`links[]`) and old-style (`nodes[].neighbors`) connection-building loops to extract `_peer`, `_peer_interface`, and `_peer_type` from `ifdata.metadata` first, falling back to top-level keys for AVD 5.x compatibility
- **`act-topgen/templates/clab-logic.j2`** — Same metadata-first extraction applied to all ContainerLab topology link-building loops (both new and old connection styles)

### Device Model Mapping
- **`act-topgen/defaults/main.yml`** — Added `act_device_model_map` dictionary that maps AVD 6.x short platform family names (e.g., `7280SR3`) to full ACT-supported model numbers (e.g., `7280SR3-48YC8`)
- **`act-topgen/templates/act-logic.j2`** — Device model assignment now looks up the platform in `act_device_model_map` with a fallback to the raw platform string; also added `ceoslab` to the list of virtual platform names excluded from model assignment

### cEOS Interface Mapping (AVD 6.x digital twin)
- **`act-topgen/templates/clab-interface-mapping.j2`** — New template that generates an `interface_mapping.json` file mapping `eth0` → `Management1` (AVD 6.x digital twin default) and all Ethernet interfaces used in the topology
- **`act-topgen/tasks/main.yml`** — New task to render the interface mapping template to `{{ clab_output_folder }}/{{ clab_interface_mapping_file }}`
- **`act-topgen/templates/clab-logic.j2`** — ContainerLab `arista_ceos` kind now includes `enforce-startup-config: true` and binds the interface mapping file into each cEOS container at `/mnt/flash/EosIntfMapping.json:ro`
- **`act-topgen/defaults/main.yml`** — New defaults: `clab_interface_mapping_file` (`interface_mapping.json`), `clab_mgmt_interface_name` (`Management1`)

### Default Changes
- **`act-topgen/defaults/main.yml`** — Changed `clab_static_mgmt_ip` default from `false` to `true`

### Connected Nodes Fix
- **`act-topgen/templates/act-logic.j2`** — Only adds empty `ports` list to connected nodes when the node type is `veos` (previously added for all node types, which was incorrect for `generic` nodes)

### Documentation
- **`README.md`** — Complete rewrite: renamed to "ACT & ContainerLab Topology Generation", added variable reference tables for all ACT and ContainerLab settings, AVD compatibility section, interface mapping explanation, and `update_clab_act_inventory` script documentation with usage examples
- **`act-topgen/README.md`** — Simplified to point at the top-level README for the full variable reference

### Example
- **`example/requirements.yml`** — Updated version comment from `v1.0.2` to `v1.0.8`, removed commented-out `eos_designs_to_containerlab` role entry

## Test plan
- [x] Run topology generation against an AVD 6.1 project and verify ACT topology output includes correct peer links from `metadata` fields
- [x] Run topology generation against an AVD 5.x project and verify backward compatibility (top-level peer fields still work)
- [x] Verify `interface_mapping.json` is generated with correct `Management1` mapping and all Ethernet interfaces
- [x] Verify `act_device_model_map` correctly translates short platform names in ACT topology output
- [x] Deploy a ContainerLab topology and confirm cEOS containers pick up the interface mapping and `enforce-startup-config` setting
- [x] Verify connected nodes of type `generic` no longer get an empty `ports` list in ACT output