### PR TITLE
Add AVD 6.1 support for metadata-based peer fields

### DIFF
--- a/act-topgen/templates/act-logic.j2
+++ b/act-topgen/templates/act-logic.j2
@@ -29,6 +29,9 @@
 {%                  endif %}
 {%             break %}
 {%         endfor %}
+{%         if "ip_addr" not in node_dict[nodename] and hostvars[node].act_mgmt_ip is defined and hostvars[node].act_mgmt_ip | length > 0 %}
+{%             do node_dict[nodename].update({"ip_addr": hostvars[node].act_mgmt_ip}) %}
+{%         endif %}
 {%         do node_dict[nodename].update({"node_type": "veos"}) %}
 {%         if act_use_old_connections %}
 {%             do node_dict[nodename].update({"neighbors": []}) %}
@@ -99,7 +102,7 @@
 {%                                 endif %}
 {%                             endif %}
 {%                         endif %}
-{%                     elif _peer not in ansible_play_hosts_all %}
+{%                     elif _peer not in ansible_play_hosts_all and "device_model" not in node_dict[nodename] %}
 {%                         do node_dict[nodename].ports.append(ifdata.name) %}
 {%                     endif %}
 {%                 endif %}
@@ -153,10 +156,10 @@
 {%                     do neighbordict.update({"neighborPort": _peer_interface}) %}
 {%                     do neighbordict.update({"port": ifdata.name}) %}
 {%                     do node_dict[nodename]["neighbors"].append(neighbordict) %}
-{%                 elif act_use_old_connections %}
+{%                 elif act_use_old_connections and "device_model" not in node_dict[nodename] %}
 {%                     do node_dict[nodename].ports.append(ifdata.name) %}
 {%                 endif %}
-{%             elif "." not in ifdata.name %}
+{%             elif "." not in ifdata.name and "device_model" not in node_dict[nodename] %}
 {%                 do node_dict[nodename].ports.append(ifdata.name) %}
 {%             endif %}
 {%         endfor %}


### PR DESCRIPTION
## Summary

This PR adds support for AVD 6.1 structured config format where `peer`, `peer_interface`, and `peer_type` fields moved under a `metadata` sub-key on each `ethernet_interfaces` entry. All templates remain backward-compatible with AVD 5.x.

## Detailed Changes

### AVD 6.x Metadata Support (templates)
- **`act-topgen/templates/act-logic.j2`** — Updated both new-style (`links[]`) and old-style (`nodes[].neighbors`) connection-building loops to extract `_peer`, `_peer_interface`, and `_peer_type` from `ifdata.metadata` first, falling back to top-level keys for AVD 5.x compatibility
- **`act-topgen/templates/clab-logic.j2`** — Same metadata-first extraction applied to all ContainerLab topology link-building loops (both new and old connection styles)

### Device Model Mapping
- **`act-topgen/defaults/main.yml`** — Added `act_device_model_map` dictionary that maps AVD 6.x short platform family names (e.g., `7280SR3`) to full ACT-supported model numbers (e.g., `7280SR3-48YC8`)
- **`act-topgen/templates/act-logic.j2`** — Device model assignment now looks up the platform in `act_device_model_map` with a fallback to the raw platform string; also added `ceoslab` to the list of virtual platform names excluded from model assignment

### cEOS Interface Mapping (AVD 6.x digital twin)
- **`act-topgen/templates/clab-interface-mapping.j2`** — New template that generates an `interface_mapping.json` file mapping `eth0` → `Management1` (AVD 6.x digital twin default) and all Ethernet interfaces used in the topology
- **`act-topgen/tasks/main.yml`** — New task to render the interface mapping template to `{{ clab_output_folder }}/{{ clab_interface_mapping_file }}`
- **`act-topgen/templates/clab-logic.j2`** — ContainerLab `arista_ceos` kind now includes `enforce-startup-config: true` and binds the interface mapping file into each cEOS container at `/mnt/flash/EosIntfMapping.json:ro`
- **`act-topgen/defaults/main.yml`** — New defaults: `clab_interface_mapping_file` (`interface_mapping.json`), `clab_mgmt_interface_name` (`Management1`)

### ACT Management IP Fallback & Port Fixes
- **`act-topgen/templates/act-logic.j2`** — Fall back to `hostvars[node].act_mgmt_ip` when no management IP is found from the interface loop
- **`act-topgen/templates/act-logic.j2`** — Skip appending unconnected interface ports to nodes that have a `device_model` set (both new-style links, old-style neighbors, and non-peer interface fallback)

### Default Changes
- **`act-topgen/defaults/main.yml`** — Changed `clab_static_mgmt_ip` default from `false` to `true`

### Connected Nodes Fix
- **`act-topgen/templates/act-logic.j2`** — Only adds empty `ports` list to connected nodes when the node type is `veos` (previously added for all node types, which was incorrect for `generic` nodes)

### Documentation
- **`README.md`** — Complete rewrite: renamed to "ACT & ContainerLab Topology Generation", added variable reference tables for all ACT and ContainerLab settings, AVD compatibility section, interface mapping explanation, and `update_clab_act_inventory` script documentation with usage examples
- **`act-topgen/README.md`** — Simplified to point at the top-level README for the full variable reference

### Example
- **`example/requirements.yml`** — Updated version comment from `v1.0.2` to `v1.0.8`, removed commented-out `eos_designs_to_containerlab` role entry

## Test plan
- [ ] Run topology generation against an AVD 6.1 project and verify ACT topology output includes correct peer links from `metadata` fields
- [ ] Run topology generation against an AVD 5.x project and verify backward compatibility (top-level peer fields still work)
- [ ] Verify `interface_mapping.json` is generated with correct `Management1` mapping and all Ethernet interfaces
- [ ] Verify `act_device_model_map` correctly translates short platform names in ACT topology output
- [ ] Deploy a ContainerLab topology and confirm cEOS containers pick up the interface mapping and `enforce-startup-config` setting
- [ ] Verify connected nodes of type `generic` no longer get an empty `ports` list in ACT output
- [ ] Verify `act_mgmt_ip` host var is used as fallback when management interface has no IP
- [ ] Verify nodes with `device_model` set do not get extra ports appended